### PR TITLE
iter27

### DIFF
--- a/internal/config/testdata/config.json
+++ b/internal/config/testdata/config.json
@@ -1,4 +1,5 @@
 {
     "address": "config.local:8080",
-    "poll_interval": "3"
+    "poll_interval": "3",
+    "trusted_subnet": "192.168.0.0/24"
 }

--- a/internal/router/router_benchmark_test.go
+++ b/internal/router/router_benchmark_test.go
@@ -51,7 +51,7 @@ func BenchmarkRouter_updatesHandler(b *testing.B) {
 		Return(nil).
 		AnyTimes()
 
-	router, err := NewRouter(logger, auditor, storeMock, nil, "")
+	router, err := NewRouter(logger, auditor, storeMock, nil, "", "")
 	require.NoError(b, err)
 
 	body, _ := json.Marshal(metrics)

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -149,7 +149,7 @@ func TestRouter_updateMetricJSON(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(data))
 			rr := httptest.NewRecorder()
 
-			r, err := NewRouter(l, a, st, nil, "")
+			r, err := NewRouter(l, a, st, nil, "", "")
 			require.NoError(t, err)
 
 			r.updateMetricJSON(rr, req)
@@ -277,7 +277,7 @@ func TestRouter_getMetricJSON(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(data))
 			rr := httptest.NewRecorder()
 
-			r, err := NewRouter(l, a, st, nil, "")
+			r, err := NewRouter(l, a, st, nil, "", "")
 			require.NoError(t, err)
 
 			r.getMetricJSON(rr, req)
@@ -299,7 +299,7 @@ func TestRouter_TestRoutes(t *testing.T) {
 	st := memstorage.NewMemoryStorage()
 	l := slog.New(slog.DiscardHandler)
 	a := audit.NewAuditor()
-	r, err := NewRouter(l, a, st, nil, "")
+	r, err := NewRouter(l, a, st, nil, "", "")
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(r.router)
@@ -553,7 +553,7 @@ func TestRouter_updateMetric(t *testing.T) {
 				nil,
 			)
 			rr := httptest.NewRecorder()
-			r, err := NewRouter(l, a, st, nil, "")
+			r, err := NewRouter(l, a, st, nil, "", "")
 			require.NoError(t, err)
 
 			chiCtx := chi.NewRouteContext()
@@ -649,7 +649,7 @@ func TestRouter_getMetric(t *testing.T) {
 
 			rr := httptest.NewRecorder()
 
-			r, err := NewRouter(l, a, st, nil, "")
+			r, err := NewRouter(l, a, st, nil, "", "")
 			require.NoError(t, err)
 
 			chiCtx := chi.NewRouteContext()
@@ -720,7 +720,7 @@ func TestRouter_pingHandler(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/ping", nil)
 			rr := httptest.NewRecorder()
 
-			router, err := NewRouter(l, a, storeMock, nil, "")
+			router, err := NewRouter(l, a, storeMock, nil, "", "")
 			require.NoError(t, err)
 
 			router.pingHandler(rr, req)
@@ -735,7 +735,7 @@ func TestRouter_updatesHandler(t *testing.T) {
 	st := memstorage.NewMemoryStorage()
 	l := slog.New(slog.DiscardHandler)
 	a := audit.NewAuditor()
-	r, err := NewRouter(l, a, st, nil, "")
+	r, err := NewRouter(l, a, st, nil, "", "")
 	require.NoError(t, err)
 
 	type want struct {
@@ -857,7 +857,7 @@ func TestRouter_rootHandler(t *testing.T) {
 	)
 	repo := memstorage.NewMemoryStorage()
 	auditor := audit.NewAuditor()
-	router, err := NewRouter(logger, auditor, repo, nil, "")
+	router, err := NewRouter(logger, auditor, repo, nil, "", "")
 	require.NoError(t, err)
 
 	m1, _ := model.NewMetric("test_gauge", model.GaugeType)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -127,6 +127,7 @@ func Run() error {
 		st,
 		[]byte(cfg.SecretKey),
 		cfg.CryptoKey,
+		cfg.TrustedSubnet,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Инкремент 27

Добавьте в конфигурационный JSON-файл сервера поле trusted_subnet (тип string, переменная окружения TRUSTED_SUBNET, флаг -t), в которое можно передать строковое представление бесклассовой адресации (CIDR).

Добавьте в запрос агента заголовок X-Real-IP, в котором должен содержаться IP-адрес хоста агента.

При отправке метрик агентом серверу нужно проверять, что переданный в заголовке запроса X-Real-IP IP-адрес агента входит в доверенную подсеть, в противном случае возвращать статус ответа 403 Forbidden.

При пустом значении переменной trusted_subnet метрики должны обрабатываться сервером без дополнительных ограничений.

- [ ] test
- [ ] test